### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=C/D
 maintainer=C/D <cosmok82@gmail.com>
 sentence=This is a library to drive a 1.8" SPI displays.
 paragraph=This is a library to drive a 1.8" SPI displays.
+category=Display
 url=http://creativityslashdesign.tk
 architectures=esp8266


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library C_D LCD is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
