### PR TITLE
Remove redundant paragraph text from library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,6 @@ version=1.1.0
 author=C/D
 maintainer=C/D <cosmok82@gmail.com>
 sentence=This is a library to drive a 1.8" SPI displays.
-paragraph=This is a library to drive a 1.8" SPI displays.
+paragraph=
 url=http://creativityslashdesign.tk
 architectures=esp8266


### PR DESCRIPTION
The Arduino IDE's Library Manager displays the text defined in the library.properties paragraph field immediately after the sentence text so it's not desirable to duplicate the sentence text in paragraph.