### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,43 +6,43 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-C_D_LCD				KEYWORD1
+C_D_LCD	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-LCDCommand 	  		KEYWORD2
-LCDData		  		KEYWORD2
+LCDCommand	KEYWORD2
+LCDData	KEYWORD2
 
-initDISPLAY	  		KEYWORD2
+initDISPLAY	KEYWORD2
 
-setAddrWindow		KEYWORD2
-fillColor			KEYWORD2
-drawPixel			KEYWORD2
-drawLine			KEYWORD2
-setWidth			KEYWORD2
-setHeight			KEYWORD2
-getWidth			KEYWORD2
-getHeight			KEYWORD2
-setRotation			KEYWORD2
-drawFastVLine		KEYWORD2
-drawFastHLine		KEYWORD2
-drawRect			KEYWORD2
-fillRect			KEYWORD2
-fillScreen			KEYWORD2
-lcdTest				KEYWORD2
-drawCircle			KEYWORD2
+setAddrWindow	KEYWORD2
+fillColor	KEYWORD2
+drawPixel	KEYWORD2
+drawLine	KEYWORD2
+setWidth	KEYWORD2
+setHeight	KEYWORD2
+getWidth	KEYWORD2
+getHeight	KEYWORD2
+setRotation	KEYWORD2
+drawFastVLine	KEYWORD2
+drawFastHLine	KEYWORD2
+drawRect	KEYWORD2
+fillRect	KEYWORD2
+fillScreen	KEYWORD2
+lcdTest	KEYWORD2
+drawCircle	KEYWORD2
 drawCircleHelper	KEYWORD2
 fillCircleHelper	KEYWORD2
-fillCircle			KEYWORD2
-fillRoundRect		KEYWORD2
-drawChar			KEYWORD2
-setCursor			KEYWORD2
-setTextSize			KEYWORD2
-setTextColor		KEYWORD2
-setTextColor		KEYWORD2
-setTextWrap			KEYWORD2
-getRotation			KEYWORD2
+fillCircle	KEYWORD2
+fillRoundRect	KEYWORD2
+drawChar	KEYWORD2
+setCursor	KEYWORD2
+setTextSize	KEYWORD2
+setTextColor	KEYWORD2
+setTextColor	KEYWORD2
+setTextWrap	KEYWORD2
+getRotation	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords